### PR TITLE
streamline handling of generic sites / spatial locations

### DIFF
--- a/R/gdalcubes-methods.R
+++ b/R/gdalcubes-methods.R
@@ -1,6 +1,8 @@
-## Replace with megacube_extract
+
+########## DEPRECATED ##########################
+## Replaced with megacube_extract
 ## May need efi-format generalized appropriately
-## Then can deprecate all methods here.
+
 
 #' cube_extract
 #'
@@ -25,6 +27,8 @@ cube_extract <- function(reference_datetime,
                          url_builder = gefs_urls,
                          cycle = "00",
                          shm = NULL) {
+
+  sites <- sites_format(sites)
 
   # overload time dimension as time + ensemble
   date_time <- reference_datetime + lubridate::hours(horizon)
@@ -87,6 +91,15 @@ efi_format_cubeextract <- function(dfs,
                   horizon = datetime - lubridate::as_datetime(reference_datetime))
   df
 }
+
+
+
+
+
+
+
+
+
 
 
 
@@ -216,8 +229,3 @@ grib_to_tif <- function(ens,
                          COG=TRUE,
                          creation_options = creation_options)
 }
-
-
-
-
-

--- a/R/gefs-methods.R
+++ b/R/gefs-methods.R
@@ -32,7 +32,7 @@ gefs_to_parquet <- function(dates = Sys.Date() - 1L,
                             partitioning = c("reference_datetime",
                                              "site_id")) {
 
-  # N.B. partitioning on site_id is broken in arrow 11.x
+  # N.B. partitioning on site_id can fail in arrow 11.x
   gdalcubes_cloud_config()
   assert_gdal_version("3.4.0")
   family <- "ensemble"
@@ -40,7 +40,7 @@ gefs_to_parquet <- function(dates = Sys.Date() - 1L,
   if(any(grepl("gespr", ensemble))) family <- "spread"
 
 
-
+  sites <- sites_format(sites)
 
   lapply(dates, function(reference_datetime) {
     message(reference_datetime)

--- a/R/sites_format.R
+++ b/R/sites_format.R
@@ -5,6 +5,11 @@ sites_format <- function(sites) {
   if (!("FID" %in% vars)) {
     sites <- tibble::rowid_to_column(sites, "FID")
   }
+
+  if (!("site_id" %in% vars)) {
+    sites <- tibble::rowname_to_column(sites, "site_id")
+  }
+
   if (!inherits(sites, "sf")) {
     longitude <- grepl("^[Ll]ong", vars)
     latitude <- grepl("^[Ll]at", vars)

--- a/R/sites_format.R
+++ b/R/sites_format.R
@@ -1,0 +1,16 @@
+
+
+sites_format <- function(sites) {
+  vars <- colnames(sites)
+  if (!("FID" %in% vars)) {
+    sites <- tibble::rowid_to_column(sites, "FID")
+  }
+  if (!inherits(sites, "sf")) {
+    longitude <- grepl("^[Ll]ong", vars)
+    latitude <- grepl("^[Ll]at", vars)
+    sites <- sf::st_as_sf(coords=c(longitude,latitude), crs=4326)
+  }
+  sites
+}
+
+

--- a/R/sites_format.R
+++ b/R/sites_format.R
@@ -7,7 +7,7 @@ sites_format <- function(sites) {
   }
 
   if (!("site_id" %in% vars)) {
-    sites <- tibble::rowname_to_column(sites, "site_id")
+    sites <- tibble::rownames_to_column(sites, "site_id")
   }
 
   if (!inherits(sites, "sf")) {


### PR DESCRIPTION
- Automatically add FID (feature id) column to sites.
- Automatically coerce data frame with detectable lat/long columns into an sf object.

For example, extraction from a data.frame of lat-long locations:

```r
library(gefs4cast)
gdalcubes::gdalcubes_options(parallel=TRUE)

sites_df <- data.frame(site_id = c("A", "B"), lat = c(0,1), long = c(0,1))
dest <- tempfile()

# Grab GEFS
gefs_to_parquet(as.Date("2022-01-01"),
                ensemble = gefs_ensemble()[1:4],
                path = dest, 
                sites = sites)
```

Extraction based on polygons:  

```
sites <- spData::world |> dplyr::filter(name_long == "India")

dest2 <- tempfile()

gefs_to_parquet(as.Date("2022-01-01"),
                ensemble = "geavg",
                path = dest2, 
                sites = sites)
```                
